### PR TITLE
Path to Babel, npm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+BABEL=node_modules/.bin/babel
 all:
+	npm install
 	@mkdir -p out
-	@babel lib\
+	@$(BABEL) lib\
 		--optional runtime\
 		--out-dir out\
 	 	--source-maps true


### PR DESCRIPTION
I don’t have babel installed globally, this patches the Makefile
also, run npm install first
