### PR TITLE
Add some getting-started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,35 @@ This plugin will look for a coverageconfig.json recusively up from the active do
 
 [Video](https://www.youtube.com/watch?v=umXk8o_7Dss)
 
+# Getting Started
+
+* Install and run [istanbul](https://www.npmjs.com/package/istanbul) - this will generate a `coverage/` directory.
+* Click the **Getting Started** button on the
+[marketplace](https://marketplace.visualstudio.com/items/bradleymeck.codecover) and follow the directions
+* Search for `Code Cover` and install the extension
+* Restart VS Code
+* Place a `coverageconfig.json` file (see below) in the source directory next to your source.
+
+# Configuration
+
 ## coverageconfig.json
 
 ```
 {
 	"coverage": ["../coverage/lcov.info"],
-	"sourcemapped": ["../out/server/**.js"]
+	"sourcemapped": ["../out/server/**.js"],
+	"automaticallyShow": true,
+	"ignore": ["*.json"]
 }
 ```
 
 It expects `coverage` to be an array of filepaths to LCOV files.
 
 It allows `sourcemapped` to be an array of file patterns that may contain sourcemaps to the files in the directory where `coverageconfig.json` is placed.
+
+It allows `automaticallyShow` to be a boolean indicating whether to highlight covered lines automatically or only on click
+
+It allows `ignore` which is an array of file patterns of source files to ignore
 
 Due to code coverage being applied to transformed files in JS, there is often a difference in the generated files that are executed and the original source files that a developer edits.
 


### PR DESCRIPTION
Update to the docs. It turns out to be very simple to install this extension!

Fixes: https://github.com/bmeck/vscode-code-cover/issues/2
